### PR TITLE
support for LEDs and debug PINs in OpenWSN

### DIFF
--- a/bsp/boards/riot-adaption/debugpins.c
+++ b/bsp/boards/riot-adaption/debugpins.c
@@ -1,110 +1,151 @@
 /**
-\brief riot-adaption-specific definition of the "debugpins" bsp module.
-
-\author Peter Kietzmann <peter.kietzmann@haw-hamburg.de>, July 2017.
-*/
-#include <stdint.h>
+ * @brief Provides an adaption of OpenWSN debug pin handling to RIOTs handling of GPIOs. 
+ *
+ * @author      Peter Kietzmann <peter.kietzmann@haw.de>
+ * @author      Michael Frey <michael.frey@msasafety.com> 
+ */
 #include "debugpins.h"
 
-//=========================== defines =========================================
+#include "debugpins_riot.h"
 
-//=========================== variables =======================================
+#include <stdint.h>
+#include <string.h>
 
-//=========================== prototypes ======================================
+/** holds the internal configuration for debug pins */
+static debugpins_config_t configuration;
 
-//=========================== public ==========================================
+/**
+ * Sets the debug pins for a specific board for OpenWSN
+ * 
+ * @param[in] user_config A configuration of GPIO pins used for debugging. Unused pins need to be defined as GPIO_UNDEF
+ */
+void debugpins_riot_init(debugpins_config_t *user_config) {
+	memset(&configuration, GPIO_UNDEF, sizeof(debugpins_config_t));
+
+    if (user_config != NULL) {
+    	memcpy(&configuration, user_config, sizeof(debugpins_config_t));
+    }
+
+    debugpins_frame_clr();
+    debugpins_slot_clr();
+    debugpins_fsm_clr();
+    debugpins_task_clr();
+    debugpins_isr_clr();
+    debugpins_radio_clr();
+}
 
 void debugpins_init(void) {
-    // frame
-    // slot
-    // fsm
-    // task
-    // isr
-    // isruarttx
-    // isruartrx
-    // radio
+	/**
+     * not implemented since the configuration is dependent on the board configuration. The
+     * configuration takes place in the debugpins_riot_init(debugpins_config_t *user) 
+     * function.
+	 */
 }
 
 void debugpins_frame_toggle(void) {
-    // flip the pin 
+	if (configuration.frame != GPIO_UNDEF) {
+		gpio_toggle(configuration.frame);
+	}
 }
 
 void debugpins_frame_clr(void) {
-    // set pin low
+	if (configuration.frame != GPIO_UNDEF) {
+		gpio_clear(configuration.frame);
+	}
 }
 
 void debugpins_frame_set(void) {
-    // set pin high
+	if (configuration.frame != GPIO_UNDEF) {
+		gpio_set(configuration.frame);
+	}
 }
 
 void debugpins_slot_toggle(void) {
-
+	if(configuration.slot != GPIO_UNDEF) { 
+		gpio_toggle(configuration.slot);
+	}
 }
 
 void debugpins_slot_clr(void) {
-
+	if(configuration.slot != GPIO_UNDEF) { 
+		gpio_clear(configuration.slot);
+	}
 }
 
 void debugpins_slot_set(void) {
-
+	if(configuration.slot != GPIO_UNDEF) { 
+		gpio_set(configuration.slot);
+	}
 }
 
 void debugpins_fsm_toggle(void) {
-
+	if (configuration.fsm != GPIO_UNDEF) {
+		gpio_toggle(configuration.fsm);
+	}
 }
 
 void debugpins_fsm_clr(void) {
-
+	if (configuration.fsm != GPIO_UNDEF) {
+		gpio_clear(configuration.fsm);
+	}
 }
 
 void debugpins_fsm_set(void) {
-
+	if (configuration.fsm != GPIO_UNDEF) {
+		gpio_set(configuration.fsm);
+	}
 }
 
 void debugpins_task_toggle(void) {
-
+	if (configuration.task != GPIO_UNDEF) {
+		gpio_toggle(configuration.task);
+	}
 }
 
 void debugpins_task_clr(void) {
-
+	if (configuration.task != GPIO_UNDEF) {
+		gpio_clear(configuration.task);
+	}
 }
 
 void debugpins_task_set(void) {
-
+	if (configuration.task != GPIO_UNDEF) {
+		gpio_set(configuration.task);
+	}
 }
 
 void debugpins_isr_toggle(void) {
-
+	if (configuration.isr != GPIO_UNDEF) {
+		gpio_toggle(configuration.isr);
+	}
 }
 
 void debugpins_isr_clr(void) {
-
+	if (configuration.isr != GPIO_UNDEF) {
+		gpio_clear(configuration.isr);
+	}
 }
 
 void debugpins_isr_set(void) {
-
-}
-
-void debugpins_isruarttx_toggle(void) {
-
-}
-
-void debugpins_isruarttx_clr(void) {
-
-}
-
-void debugpins_isruarttx_set(void) {
-
+	if (configuration.isr != GPIO_UNDEF) {
+		gpio_set(configuration.isr);
+	}
 }
 
 void debugpins_radio_toggle(void) {
-
+	if (configuration.radio != GPIO_UNDEF) {
+		gpio_toggle(configuration.radio);
+	}
 }
 
 void debugpins_radio_clr(void) {
-
+	if (configuration.radio != GPIO_UNDEF) {
+		gpio_clear(configuration.radio);
+	}
 }
 
 void debugpins_radio_set(void) {
-
+	if (configuration.radio != GPIO_UNDEF) {
+		gpio_set(configuration.radio);
+	}
 }

--- a/bsp/boards/riot-adaption/debugpins_riot.h
+++ b/bsp/boards/riot-adaption/debugpins_riot.h
@@ -1,0 +1,27 @@
+/**
+ * @brief Provides an adaption of OpenWSN debug pin handling to RIOTs handling of GPIOs. 
+ *
+ * @author      Peter Kietzmann <peter.kietzmann@haw.de>
+ * @author      Michael Frey <michael.frey@msasafety.com> 
+ */
+#ifndef __DEBUGPINS_RIOT_H
+#define __DEBUGPINS_RIOT_H
+
+/** RIOT specific includes */
+#include "periph/gpio.h"
+
+/**
+ * Holds a configuration of debug pins for debugging OpenWSN
+ */
+typedef struct debugpins_config {
+	gpio_t frame;       /**< debug pin for frames */
+	gpio_t slot;        /**< debug pin for slots  */
+	gpio_t fsm;         /**< debug pin for fsm */
+	gpio_t task;        /**< debug pin for tasks */
+	gpio_t isr;         /**< debug pin for interrupt service routines */
+	gpio_t radio;       /**< debug pin for the radio */
+} debugpins_config_t;
+
+void debugpins_riot_init(debugpins_config_t *user_config);
+
+#endif /* __DEBUGPINS_RIOT_H */

--- a/bsp/boards/riot-adaption/leds.c
+++ b/bsp/boards/riot-adaption/leds.c
@@ -1,107 +1,208 @@
 /**
-\brief riot-adaption-specific definition of the "leds" bsp module.
-*/
+ * @brief Provides an adaption of OpenWSN LED handling to RIOTs handling of LEDs. 
+ *
+ * The adaption aims to support every (suited) RIOT board. However, this comes with the 
+ * limiation of not providing leds_{type}_isOn function calls since these differ from 
+ * board to board. Also, this adaption assumes that there are four LEDs, while some boards
+ * such as the iotlab-m3 have only three LEDs.
+ *
+ * @author      Peter Kietzmann <peter.kietzmann@haw-hamburg.de>
+ * @author      Michael Frey <michael.frey@msasafety.com> 
+ */
 
 #include "leds.h"
 
-//=========================== defines =========================================
+/** includes specific to riot */
+#include "board.h"
+#include "periph/gpio.h"
 
-//=========================== variables =======================================
+#include <stdint.h>
 
-//=========================== prototypes ======================================
+#ifndef LED0_PIN
+#define LED0_ON
+#define LED0_OFF
+#define LED0_TOGGLE
+#endif 
 
-//=========================== public ==========================================
+#ifndef LED1_PIN
+#define LED1_ON
+#define LED1_OFF
+#define LED1_TOGGLE
+#endif 
 
+#ifndef LED2_PIN
+#define LED2_ON
+#define LED2_OFF
+#define LED2_TOGGLE
+#endif 
+
+#ifndef LED3_PIN
+#define LED3_ON
+#define LED3_OFF
+#define LED3_TOGGLE
+#endif 
+
+/**
+ * Provides a simple delay by means of iterating over a 32-bit variable
+ */
+static void leds_delay(void);
+
+/**
+ * Configure four leds as output which provide error, sync, debug, and
+ * radio status information.
+ */
 void leds_init(void) {
-    // configure 4 leds as output, presents as error, sync, debug, radio
+    /** led color: red (ERROR) */
+    #ifdef LED0_PIN
+        gpio_init(LED0_PIN, GPIO_OUT);
+        gpio_set(LED0_PIN);
+    #endif
+
+    /** led color: orange (RADIO) */
+    #ifdef LED1_PIN
+        gpio_init(LED1_PIN, GPIO_OUT);
+        gpio_set(LED1_PIN);
+    #endif
+
+    /** led color: green (SYNC) */
+    #ifdef LED2_PIN
+        gpio_init(LED2_PIN, GPIO_OUT);
+        gpio_set(LED2_PIN);
+    #endif
+
+    /** led color: yellow */
+    #ifdef LED3_PIN
+        gpio_init(LED3_PIN, GPIO_OUT);
+        gpio_set(LED3_PIN);
+    #endif
 }
 
 void leds_error_on(void) {
-
+   	LED0_ON;
 }
 
 void leds_error_off(void) {
-
+   	LED0_OFF;
 }
 
 void leds_error_toggle(void) {
-
+   	LED0_TOGGLE;
 }
 
 uint8_t leds_error_isOn(void) {
+	/** not implemented */
     return 0;
 }
 
-void leds_error_blink(void) {
-    // blink error led for 10 seconds
-    // this function is called when there is critical error happens,
-    // the board will blink error led and reset later
+/**
+ * Let the error led blink for "10 seconds". 
+ */
+void leds_error_blink(void) {    
+	for (uint8_t i = 0; i < 16; i++) {
+        leds_error_toggle();
+        leds_delay();
+    }
 }
 
 void leds_radio_on(void) {
-
+   	LED1_ON;
 }
 
 void leds_radio_off(void) {
-
+   	LED1_OFF;
 }
 
 void leds_radio_toggle(void) {
-
+   	LED1_TOGGLE;
 }
 
 uint8_t leds_radio_isOn(void) {
+	/** not implemented */
     return 0;
 }
 
 void leds_sync_on(void) {
-
+	LED2_ON;
 }
 
 void leds_sync_off(void) {
-
+	LED2_OFF;
 }
 
 void leds_sync_toggle(void) {
-
+	LED2_TOGGLE;
 }
 
 uint8_t leds_sync_isOn(void) {
+	/** not implemented */
     return 0;
 }
 
 void leds_debug_on(void) {
-
+	LED3_ON;
 }
 
 void leds_debug_off(void) {
-
+	LED3_OFF;
 }
 
 void leds_debug_toggle(void) {
-
+	LED3_TOGGLE;
 }
 
 uint8_t leds_debug_isOn(void) {
+	/** not implemented */
     return 0;
 }
 
 void leds_all_on(void) {
-
+    leds_error_on();
+    leds_radio_on();
+    leds_sync_on();
+    leds_debug_on();
 }
 
 void leds_all_off(void) {
-
+    leds_error_off();
+    leds_radio_off();
+    leds_sync_off();
+    leds_debug_off();
 }
 
 void leds_all_toggle(void) {
-
+    leds_error_toggle();
+    leds_radio_toggle();
+    leds_sync_toggle();
+    leds_debug_toggle();
 }
 
 void leds_circular_shift(void) {
-    // turn on and off each led in sequence
+    leds_error_on();
+    leds_delay();
+    leds_error_off();
+    leds_delay();
+    leds_radio_on();
+    leds_delay();
+    leds_radio_off();
+    leds_delay();
+    leds_sync_on();
+    leds_delay();
+    leds_sync_off();
+    leds_delay();
+    leds_debug_on();
+    leds_delay();
+    leds_debug_off();
 }
 
+/**
+ * Turns on and off the leds as a binary counter.
+ */
 void leds_increment(void) {
-    // turn on and off the leds as a binary counter
+	/** not implemented */
+	return;
+}
+
+
+static void leds_delay(void) {
+    for(uint32_t i = 0; i < 0x7FFF8; i++);
 }

--- a/inc/opendefs.h
+++ b/inc/opendefs.h
@@ -177,6 +177,7 @@ enum {
    COMPONENT_UMONITOR                  = 0x2a,
    COMPONENT_CJOIN                     = 0x2b,
    COMPONENT_OPENOSCOAP                = 0x2c,
+   COMPONENT_RIOT                      = 0x2d,
 };
 
 /**


### PR DESCRIPTION
Provides support for LEDs and debug pins in OpenWSNs (virtual) riot adaption board. OpenWSN makes uses for up to four LEDs which not every board supports. Hence, the adaption makes use of a dummy macro which execution simply "does nothing" (and fails silently), e.g.

```C
#ifndef LED3_PIN
#define LED3_ON
#define LED3_OFF
#define LED3_TOGGLE
#endif 

...

void leds_debug_off(void) {
	LED3_OFF;
}
```

Also, the debug pins need to be initialized first by an application. The corresponding function is
```C
void debugpins_riot_init(debugpins_config_t *user_config);
```
